### PR TITLE
Remove noqa = E501

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -17,7 +17,7 @@ class TestClient(AsyncTestCase):
     def test_Client_should_have_a_variable_with_a_token_manager_class(self):
         self.assertEquals(Client.token_manager_class, TokenManager)
 
-    def test_token_manager_object_should_be_an_instance_of_token_manager_class(self):  # noqa = E501
+    def test_manager_should_be_a_token_manager_class(self):
         client = Client(token_endpoint=self.end_point,
                         client_id='client-id', client_secret='client_secret')
 
@@ -30,9 +30,10 @@ class TestClient(AsyncTestCase):
     def test_should_return_a_good_request(self, Manager):
         manager = self._fake_manager(Manager, has_token=False)
 
-        with patch('tornadoalf.client.Client._authorized_fetch') as _authorized_fetch:  # noqa = E501
-            _authorized_fetch.return_value = mkfuture(Mock(code=200))
+        with patch('tornadoalf.client.Client._authorized_fetch') as (
+                   _authorized_fetch):
 
+            _authorized_fetch.return_value = mkfuture(Mock(code=200))
             response = yield self._request(Manager)
             self.assertEqual(response.code, 200)
             self.assertEqual(_authorized_fetch.call_count, 1)
@@ -43,9 +44,10 @@ class TestClient(AsyncTestCase):
     def test_should_return_a_bad_request(self, Manager):
         manager = self._fake_manager(Manager, has_token=False)
 
-        with patch('tornadoalf.client.Client._authorized_fetch') as _authorized_fetch:  # noqa = E501
-            _authorized_fetch.return_value = mkfuture(Mock(code=400))
+        with patch('tornadoalf.client.Client._authorized_fetch') as (
+                   _authorized_fetch):
 
+            _authorized_fetch.return_value = mkfuture(Mock(code=400))
             response = yield self._request(Manager)
             self.assertEqual(response.code, 400)
             self.assertEqual(_authorized_fetch.call_count, 1)
@@ -56,9 +58,10 @@ class TestClient(AsyncTestCase):
     def test_should_retry_a_bad_token_request_once(self, Manager):
         self._fake_manager(Manager, has_token=False)
 
-        with patch('tornadoalf.client.Client._authorized_fetch') as _authorized_fetch:  # noqa = E501
-            _authorized_fetch.return_value = mkfuture(Mock(code=401))
+        with patch('tornadoalf.client.Client._authorized_fetch') as (
+                   _authorized_fetch):
 
+            _authorized_fetch.return_value = mkfuture(Mock(code=401))
             response = yield self._request(Manager)
             self.assertEqual(response.code, 401)
             self.assertEqual(_authorized_fetch.call_count, 2)
@@ -68,9 +71,10 @@ class TestClient(AsyncTestCase):
     def test_should_reset_token_when_token_fails(self, Manager):
         manager = self._fake_manager(Manager, has_token=False)
 
-        with patch('tornadoalf.client.Client._authorized_fetch') as _authorized_fetch:  # noqa = E501
-            _authorized_fetch.return_value = mkfuture(Mock(code=401))
+        with patch('tornadoalf.client.Client._authorized_fetch') as (
+                   _authorized_fetch):
 
+            _authorized_fetch.return_value = mkfuture(Mock(code=401))
             response = yield self._request(Manager)
             self.assertEqual(response.code, 401)
             self.assertEqual(manager.reset_token.call_count, 1)
@@ -80,9 +84,10 @@ class TestClient(AsyncTestCase):
     def test_should_reset_token_when_gets_a_token_error(self, Manager):
         manager = self._fake_manager(Manager, has_token=False)
 
-        with patch('tornadoalf.client.Client._authorized_fetch') as _authorized_fetch:  # noqa = E501
-            _authorized_fetch.side_effect = TokenError('boom', 'boom')
+        with patch('tornadoalf.client.Client._authorized_fetch') as (
+                   _authorized_fetch):
 
+            _authorized_fetch.side_effect = TokenError('boom', 'boom')
             try:
                 yield self._request(Manager)
             except TokenError as e:


### PR DESCRIPTION
As @scorphus has appointed to me early, It's more desirable to remove the `# noqa` comments from the code and handle the tests on a more clear way.